### PR TITLE
Fix compile issue by removing stray module

### DIFF
--- a/src/flowgger/output/mod.rs
+++ b/src/flowgger/output/mod.rs
@@ -7,7 +7,6 @@ mod kafka_output;
 mod tls_output;
 #[cfg(feature = "nats-output")]
 mod nats_output;
-mod test_nats_output;
 
 #[cfg(feature = "nats-output")]
 pub use self::nats_output::NatsOutput;


### PR DESCRIPTION
## Summary
- remove unused module declaration that broke `nats-output` builds

## Testing
- `cargo build --features nats-output`

------
https://chatgpt.com/codex/tasks/task_e_684f5079ebf08320abd1c15a04be4937