### PR TITLE
Fix compile errors in NATS output

### DIFF
--- a/src/flowgger/output/nats_output.rs
+++ b/src/flowgger/output/nats_output.rs
@@ -5,7 +5,7 @@
 use {
     super::Output,
     crate::flowgger::{config::Config, merger::Merger},
-    async_nats::{jetstream, Client},
+    async_nats::{jetstream, Client, ConnectOptions},
     async_nats::jetstream::{context::PublishAckFuture, stream::StorageType},
     std::{
         path::PathBuf,
@@ -76,7 +76,6 @@ struct NatsWorker {
     merger: Option<Box<dyn Merger + Send>>,
 }
 
-use async_nats::{jetstream, Client, ConnectOptions, PublishAckFuture, stream::StorageType};
 
 #[cfg(feature = "nats-output")]
 impl NatsWorker {
@@ -86,12 +85,12 @@ impl NatsWorker {
 
         // Apply CA file if provided, to verify the server's certificate.
         if let Some(ca_file) = &self.cfg.tls_ca {
-            options = options.add_root_certificate(ca_file.clone());
+            options = options.add_root_certificates(ca_file.clone());
         }
 
         // Apply client certificate and key for mTLS client authentication.
         if let (Some(cert_file), Some(key_file)) = (&self.cfg.tls_cert, &self.cfg.tls_key) {
-            options = options.client_cert(cert_file.clone(), key_file.clone());
+            options = options.add_client_certificate(cert_file.clone(), key_file.clone());
         }
 
         // Connect to the server using the constructed options.
@@ -110,7 +109,7 @@ impl NatsWorker {
         Ok((client, js))
     }
 
-    async fn run(mut self) {
+    async fn run(self) {
         let (_, js) = self.connect().await.expect("NATS connection failed");
 
         loop {


### PR DESCRIPTION
## Summary
- fix compile errors in `nats_output`
- adjust TLS option method names

## Testing
- `cargo build --features nats-output`
- `cargo test --features nats-output` *(fails: output.file_path is missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f53fc73fc8320b8ea1e3ea18ad9bf